### PR TITLE
Refactor: Convert tests from unittest to pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,82 @@ main.py will contain your entrypoint function and this is also specified when yo
 
 I've added some unit tests as an example in the tests directory. Not all of these tests are great since it is difficult to mock some of the objects returned from the queries used by the Google compute SDK. Run the following steps to execute the unit tests.
 
-1. Install the module contained within src/modules (from root of repo) `pip install -e .`
-2. Run unit tests from within tests folder `python -m unittest test_update_vpc_peering.py`
+1. Install tox following [official documentation](https://tox.wiki/en/4.5.1/installation.html).
+2. Setup gcloud default authentication, will not make any real API calls `gcloud auth application-default login`.
+3. Run tox which will setup virtual environments, lint, and run pytest. Just run `tox` from root directory of repo.
+
+```
+~> gke-peering-event-function % tox
+lint: install_deps> python -I -m pip install 'black>=23' -e . -r ./src/requirements.txt
+.pkg: install_requires> python -I -m pip install setuptools
+.pkg: _optional_hooks> python /Users/zachbrooks/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
+.pkg: get_requires_for_build_sdist> python /Users/zachbrooks/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
+.pkg: prepare_metadata_for_build_wheel> python /Users/zachbrooks/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
+.pkg: build_sdist> python /Users/zachbrooks/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
+lint: install_package_deps> python -I -m pip install google-cloud-compute==1.11.0
+lint: install_package> python -I -m pip install --force-reinstall --no-deps /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/.tmp/package/1/update_vpc_peering-0.0.1.tar.gz
+lint: commands[0]> black .
+All done! ✨ 🍰 ✨
+4 files left unchanged.
+lint: OK ✔ in 11.25 seconds
+py311: install_deps> python -I -m pip install 'pytest>=7' -e . -r ./src/requirements.txt
+py311: install_package_deps> python -I -m pip install google-cloud-compute==1.11.0
+py311: install_package> python -I -m pip install --force-reinstall --no-deps /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/.tmp/package/2/update_vpc_peering-0.0.1.tar.gz
+py311: commands[0]> pytest tests
+============================= test session starts ==============================
+platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
+cachedir: .tox/py311/.pytest_cache
+rootdir: /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function
+collected 5 items                                                              
+
+tests/test_update_vpc_peering.py .....                                   [100%]
+
+=============================== warnings summary ===============================
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:121
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
+    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
+
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
+  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    declare_namespace(pkg)
+
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.cloud')`.
+  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    declare_namespace(pkg)
+
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2349
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2349
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2349
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2349: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
+  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    declare_namespace(parent)
+
+.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.logging')`.
+  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    declare_namespace(pkg)
+
+.tox/py311/lib/python3.11/site-packages/google/rpc/__init__.py:20
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/google/rpc/__init__.py:20: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.rpc')`.
+  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
+    pkg_resources.declare_namespace(__name__)
+
+tests/test_update_vpc_peering.py::test_return_network
+  /Users/zachbrooks/github.com/zbrooks422/gke-peering-event-function/.tox/py311/lib/python3.11/site-packages/google/auth/_default.py:78: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. See the following page for troubleshooting: https://cloud.google.com/docs/authentication/adc-troubleshooting/user-creds. 
+    warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================== 5 passed, 12 warnings in 1.38s ========================
+.pkg: _exit> python /Users/zachbrooks/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta
+  lint: OK (11.25=setup[8.90]+cmd[2.34] seconds)
+  py311: OK (9.59=setup[7.84]+cmd[1.75] seconds)
+  congratulations :) (20.87 seconds)
+```
 
 ### Functionality
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,16 @@
 [metadata]
-name = gcp-gke-vpc-updater
+name = update_vpc_peering
 version = 0.0.1
 
 [options]
 package_dir=
-    =src/modules
+    =src/packages
 packages=find:
 install_requires =
     google-cloud-compute==1.11.0
 
 [options.packages.find]
-where=src/modules
+where=src/packages
 
 [flake8]
 max-line-length = 99

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from modules.update_vpc_peering import update_vpc_peering
+from packages.update_vpc_peering import update_vpc_peering
 import base64
 import json
 import os
@@ -13,7 +13,7 @@ def update_peering(data: dict, context: dict) -> dict:
 
     Returns:
         status (dict): Dictionary containing bool status and msg
-    
+
     Raises:
     """
     data_buffer = base64.b64decode(data["data"])

--- a/src/packages/update_vpc_peering/update_vpc_peering.py
+++ b/src/packages/update_vpc_peering/update_vpc_peering.py
@@ -99,7 +99,7 @@ class updateVpcPeering:
                     "status": False,
                     "msg": f"Failed to update peering {self.peering_name}, exception {e} occured...",
                 }
-            time.sleep(wait*cnt)
+            time.sleep(wait * cnt)
         return status
 
     def check_status(self, response: object) -> bool:

--- a/tests/test_update_vpc_peering.py
+++ b/tests/test_update_vpc_peering.py
@@ -1,58 +1,64 @@
 from update_vpc_peering import update_vpc_peering
 from unittest.mock import MagicMock
 import pickle
-import unittest
+import pytest
+import os
 
 
-class TestupdateVpcPeering(unittest.TestCase):
-    def setUp(self):
-        with open("google_sdk_network_mock.data", "rb") as pfile:
-            self.network_mock_data = pickle.load(pfile)
-        self.updateVpcPeering = update_vpc_peering.updateVpcPeering(
-            project_id="fakeprojectid",
-            network_name="test-vpc-name",
-            peering_name="gke-ijsadoasoidasod-peer",
-        )
-        self.updateVpcPeering.return_network = MagicMock(
-            return_value=self.network_mock_data
-        )
-        self.updateVpcPeering.update_peering = MagicMock(
-            return_value={
-                "status": True,
-                "msg": "Successfully updated peering gke-ijsadoasoidasod-peer...",
-            }
-        )
-        self.updateVpcPeering.check_status = MagicMock(return_value=True)
-        self.updateVpcPeering.run_peering_update = MagicMock(
-            return_value={
-                "status": True,
-                "msg": "Successfully updated peering gke-ijsadoasoidasod-peer...",
-            }
-        )
-        self.updateVpcPeering.network = self.network_mock_data
+@pytest.fixture(scope="session")
+def updateVpcPeering():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    with open(f"{dir_path}/google_sdk_network_mock.data", "rb") as pfile:
+        network_mock_data = pickle.load(pfile)
+    updateVpcPeering = update_vpc_peering.updateVpcPeering(
+        project_id="fakeprojectid",
+        network_name="test-vpc-name",
+        peering_name="gke-ijsadoasoidasod-peer",
+    )
+    updateVpcPeering.return_network = MagicMock(return_value=network_mock_data)
+    updateVpcPeering.update_peering = MagicMock(
+        return_value={
+            "status": True,
+            "msg": "Successfully updated peering gke-ijsadoasoidasod-peer...",
+        }
+    )
+    updateVpcPeering.check_status = MagicMock(return_value=True)
+    updateVpcPeering.run_peering_update = MagicMock(
+        return_value={
+            "status": True,
+            "msg": "Successfully updated peering gke-ijsadoasoidasod-peer...",
+        }
+    )
+    updateVpcPeering.network = network_mock_data
+    return updateVpcPeering
 
-    def test_return_network(self):
-        network = self.updateVpcPeering.return_network()
-        network_name = network.name
-        self.assertEqual(network_name, "test-vpc-name")
 
-    def test_return_updates(self):
-        update = self.updateVpcPeering.return_updates()
-        peering_name = update.name
-        self.assertEqual(peering_name, "gke-ijsadoasoidasod-peer")
+def test_return_network(updateVpcPeering):
+    network = updateVpcPeering.return_network()
+    network_name = network.name
+    assert network_name == "test-vpc-name"
 
-    def test_update_peering(self):
-        # Todo: Build a better test
-        update = self.updateVpcPeering.return_updates()
-        status = self.updateVpcPeering.update_peering(update=update)
-        self.assertEqual(True, status["status"])
 
-    def test_check_status(self):
-        # Todo: Build a better test
-        status = self.updateVpcPeering.check_status("Response")
-        self.assertEqual(True, status)
+def test_return_updates(updateVpcPeering):
+    update = updateVpcPeering.return_updates()
+    peering_name = update.name
+    assert peering_name == "gke-ijsadoasoidasod-peer"
 
-    def test_run_peering_update(self):
-        # Todo: Build a better test
-        status = self.updateVpcPeering.run_peering_update()
-        self.assertEqual(True, status["status"])
+
+def test_update_peering(updateVpcPeering):
+    # Todo: Build a better test
+    update = updateVpcPeering.return_updates()
+    status = updateVpcPeering.update_peering(update=update)
+    assert True == status["status"]
+
+
+def test_check_status(updateVpcPeering):
+    # Todo: Build a better test
+    status = updateVpcPeering.check_status("Response")
+    assert True == status
+
+
+def test_run_peering_update(updateVpcPeering):
+    # Todo: Build a better test
+    status = updateVpcPeering.run_peering_update()
+    assert True == status["status"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+requires =
+    tox>=4
+env_list = lint, py311
+
+[testenv]
+description = run unit tests
+deps =
+    pytest>=7
+    -r./src/requirements.txt
+    -e.
+commands =
+    pytest {posargs:tests}
+
+[testenv:lint]
+description = run linters
+deps =
+    black>=23
+    -r./src/requirements.txt
+    -e.
+commands = black {posargs:.}


### PR DESCRIPTION
# What Changed

Converted unittest based tests to pytest based tests and used tox for orchestration. Updated readme with additional details.